### PR TITLE
Using vm_flags modifier for VMEM_FLAGS setting

### DIFF
--- a/XDMA/linux-kernel/xdma/cdev_ctrl.c
+++ b/XDMA/linux-kernel/xdma/cdev_ctrl.c
@@ -233,6 +233,9 @@ int bridge_mmap(struct file *file, struct vm_area_struct *vma)
 	 * prevent touching the pages (byte access) for swap-in,
 	 * and prevent the pages from being swapped out
 	 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 3, 0)
+	vm_flags_set(vma, VMEM_FLAGS);
+#else
 	vma->vm_flags |= VMEM_FLAGS;
 	/* make MMIO accessible to user space */
 	rv = io_remap_pfn_range(vma, vma->vm_start, phys >> PAGE_SHIFT,


### PR DESCRIPTION
It looks like code will break on kernel 6.3 due to the introduction of new wrappers for modifying vm_flags.

This small fix should be enough.